### PR TITLE
fix bitmap_buffer() and bitmap_buffer_mut()

### DIFF
--- a/libnyx/src/lib.rs
+++ b/libnyx/src/lib.rs
@@ -224,11 +224,11 @@ impl NyxProcess {
     }
     
     pub fn bitmap_buffer(&self) -> &[u8] {
-        self.process.bitmap
+        &self.process.bitmap[.. self.process.bitmap_size]
     }
     
     pub fn bitmap_buffer_mut(&mut self) -> &mut [u8] {
-        self.process.bitmap
+        &mut self.process.bitmap[.. self.process.bitmap_size]
     }
 
     pub fn bitmap_buffer_size(&self) -> usize {


### PR DESCRIPTION
return a slice with the actual bitmap size instead the entire buffer (which has the size of the actual shared mmap file)