### PR TITLE
add SANITIZER and STARVED exec result codes

### DIFF
--- a/fuzz_runner/src/nyx/aux_buffer.rs
+++ b/fuzz_runner/src/nyx/aux_buffer.rs
@@ -19,6 +19,8 @@ pub const NYX_HPRINTF: u8       = 2;
 pub const NYX_TIMEOUT: u8       = 3;
 pub const NYX_INPUT_WRITE: u8   = 4;
 pub const NYX_ABORT: u8         = 5;
+pub const NYX_SANITIZER: u8     = 6;
+pub const NYX_STARVED: u8       = 7;
 
 
 const AUX_BUFFER_SIZE: usize = 4096;

--- a/fuzz_runner/src/nyx/qemu_process.rs
+++ b/fuzz_runner/src/nyx/qemu_process.rs
@@ -26,7 +26,10 @@ use colored::*;
 
 
 use crate::nyx::aux_buffer::AuxBuffer;
-use crate::nyx::aux_buffer::{NYX_SUCCESS, NYX_CRASH, NYX_HPRINTF, NYX_TIMEOUT, NYX_ABORT, NYX_INPUT_WRITE};
+use crate::nyx::aux_buffer::{
+    NYX_SUCCESS, NYX_CRASH, NYX_HPRINTF, NYX_TIMEOUT, NYX_ABORT, NYX_INPUT_WRITE,
+    NYX_SANITIZER, NYX_STARVED
+};
 
 use crate::nyx::ijon_data::{SharedFeedbackData, FeedbackBuffer};
 use crate::nyx::mem_barrier::mem_barrier;
@@ -254,7 +257,7 @@ impl QemuProcess {
 
                     return Err(msg);
                 }
-                NYX_SUCCESS => {},
+                NYX_SUCCESS | NYX_STARVED => {},
                 x => {
                     panic!(" -> unkown type ? {}", x);
                 }
@@ -363,7 +366,7 @@ impl QemuProcess {
                     println!("[!] libnyx: agent abort() -> \"{}\"", String::from_utf8_lossy(&self.aux.misc.data[0..len as usize]).red());
                     break;
                 },
-                NYX_SUCCESS | NYX_CRASH | NYX_INPUT_WRITE | NYX_TIMEOUT      => {
+                NYX_SUCCESS | NYX_CRASH | NYX_INPUT_WRITE | NYX_TIMEOUT | NYX_SANITIZER | NYX_STARVED => {
                     break;
                 },
                 x => {

--- a/libnyx/src/lib.rs
+++ b/libnyx/src/lib.rs
@@ -5,7 +5,10 @@ use config::{Config, FuzzRunnerConfig};
 use fuzz_runner::nyx::qemu_process_new_from_kernel;
 use fuzz_runner::nyx::qemu_process_new_from_snapshot;
 use fuzz_runner::nyx::qemu_process::QemuProcess;
-use fuzz_runner::nyx::aux_buffer::{NYX_SUCCESS, NYX_CRASH, NYX_TIMEOUT, NYX_INPUT_WRITE, NYX_ABORT};
+use fuzz_runner::nyx::aux_buffer::{
+    NYX_SUCCESS, NYX_CRASH, NYX_TIMEOUT, NYX_INPUT_WRITE, NYX_ABORT,
+    NYX_SANITIZER, NYX_STARVED
+};
 
 use std::fmt;
 
@@ -286,12 +289,12 @@ impl NyxProcess {
             Err(_) =>  NyxReturnValue::IoError,
             Ok(_) => {
                 match self.process.aux.result.exec_result_code {
-                    NYX_SUCCESS     => NyxReturnValue::Normal,
-                    NYX_CRASH       => NyxReturnValue::Crash,
-                    NYX_TIMEOUT     => NyxReturnValue::Timeout,
-                    NYX_INPUT_WRITE => NyxReturnValue::InvalidWriteToPayload,
-                    NYX_ABORT       => NyxReturnValue::Abort,
-                    _                  => NyxReturnValue::Error,
+                    NYX_SUCCESS | NYX_STARVED       => NyxReturnValue::Normal,
+                    NYX_CRASH | NYX_SANITIZER       => NyxReturnValue::Crash,
+                    NYX_TIMEOUT                     => NyxReturnValue::Timeout,
+                    NYX_INPUT_WRITE                 => NyxReturnValue::InvalidWriteToPayload,
+                    NYX_ABORT                       => NyxReturnValue::Abort,
+                    _                               => NyxReturnValue::Error,
                 }
             }
         }


### PR DESCRIPTION
Fixes #12.

Not sure if the associations with `NyxReturnValue` are fine or more variants of it should be added for the new result codes.