### PR TITLE
ci: add build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - '**/README.md'
   pull_request:
+    paths-ignore:
+      - '**/README.md'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: cargo build
+        working-directory: libnyx


### PR DESCRIPTION
This PR adds simple CI to ensure that `libnyx` compiles in `main` branch.