### PR TITLE
Remove hardcoded configuration values

### DIFF
--- a/fuzz_runner/src/nyx/params.rs
+++ b/fuzz_runner/src/nyx/params.rs
@@ -46,7 +46,7 @@ impl QemuParams {
             FuzzRunnerConfig::QemuSnapshot(x) => {
                 cmd.push(x.qemu_binary.to_string());
                 cmd.push("-drive".to_string());
-                cmd.push(format!("file={},format=raw,index=0,media=disk", x.hda.to_string()));
+                cmd.push(format!("file={},index=0,media=disk", x.hda.to_string()));
             },
         }
 

--- a/fuzz_runner/src/nyx/params.rs
+++ b/fuzz_runner/src/nyx/params.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use crate::{config::{Config, FuzzRunnerConfig, QemuNyxRole}, QemuProcess};
 
 pub struct QemuParams {
@@ -15,6 +16,7 @@ pub struct QemuParams {
     pub hprintf_fd: Option<i32>,
 
     pub aux_buffer_size: usize,
+    pub time_limit: Duration,
 }
 
 impl QemuParams {
@@ -191,6 +193,7 @@ impl QemuParams {
             cow_primary_size: fuzzer_config.fuzz.cow_primary_size,
             hprintf_fd: fuzzer_config.runtime.hprintf_fd(),
             aux_buffer_size: fuzzer_config.runtime.aux_buffer_size(),
+            time_limit: fuzzer_config.fuzz.time_limit
         }
     }
 

--- a/fuzz_runner/src/nyx/params.rs
+++ b/fuzz_runner/src/nyx/params.rs
@@ -150,8 +150,11 @@ impl QemuParams {
                     match fuzzer_config.runtime.process_role() {
                         QemuNyxRole::StandAlone => {
                             cmd.push("-fast_vm_reload".to_string());
-                            cmd.push(format!("path={}/snapshot/,load=off,pre_path={},skip_serialization=on", workdir, x.presnapshot));
-
+                            if x.presnapshot.is_empty() {
+                                cmd.push(format!("path={}/snapshot/,load=off,skip_serialization=on", workdir));
+                            } else {
+                                cmd.push(format!("path={}/snapshot/,load=off,pre_path={},skip_serialization=on", workdir, x.presnapshot));
+                            }
                         },
                         QemuNyxRole::Parent => {
                             cmd.push("-fast_vm_reload".to_string());

--- a/fuzz_runner/src/nyx/qemu_process.rs
+++ b/fuzz_runner/src/nyx/qemu_process.rs
@@ -205,7 +205,7 @@ impl QemuProcess {
             return Err(format!("cannot launch QEMU-Nyx..."));
         }
 
-        let mut aux_buffer = {
+        let aux_buffer = {
             let aux_shm_f = OpenOptions::new()
                 .read(true)
                 .write(true)
@@ -291,12 +291,12 @@ impl QemuProcess {
             1 => println!("[!] libnyx: coverage mode: compile-time instrumentation"),
             _ => panic!("unkown aux_buffer.cap.agent_trace_bitmap value"),
         };
-        
+
         println!("[!] libnyx: qemu #{} is ready:", params.qemu_id);
 
         aux_buffer.config.reload_mode = 1;
-        aux_buffer.config.timeout_sec = 0;
-        aux_buffer.config.timeout_usec = 500_000;
+        aux_buffer.config.timeout_sec = params.time_limit.as_secs() as u8;
+        aux_buffer.config.timeout_usec = params.time_limit.subsec_micros();
         aux_buffer.config.changed = 1;
 
         return Ok(QemuProcess {


### PR DESCRIPTION
This merge request does the following things:

1. It removes the assumption that the disk is in the `raw` format and lets QEMU detect the disk type, which will allow disks in the `raw` and `qcow2` format to be used
2. It uses the `time_limit` configuration option when setting the default timeout value instead of setting it to a hardcoded value of `500ms`
3. Allows starting a snapshot-mode fuzzing run without having to require a pre-snapshot ready (boot the vm instead)