### PR TITLE
Add dump_pt_trace config parameter

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -141,7 +141,8 @@ pub struct FuzzerConfig {
     pub write_protected_input_buffer: bool,
     pub cow_primary_size: Option<u64>,
     pub ipt_filters: [IptFilter;4],
-    pub target_hash: Option<[u8; 20]>
+    pub target_hash: Option<[u8; 20]>,
+    pub dump_pt_trace: bool,
 }
 impl FuzzerConfig{
 
@@ -200,6 +201,7 @@ impl FuzzerConfig{
                 config.ip3,
             ],
             target_hash: target_hash,
+            dump_pt_trace: config.dump_pt_trace,
         }
     }
 }

--- a/config/src/loader.rs
+++ b/config/src/loader.rs
@@ -64,6 +64,12 @@ pub struct FuzzerConfigLoader {
     pub snapshot_placement: Option<SnapshotPlacement>,
     pub dump_python_code_for_inputs: Option<bool>,
     pub exit_after_first_crash: Option<bool>,
+    #[serde(default = "default_dump_pt_trace")]
+    pub dump_pt_trace: bool,
+}
+
+fn default_dump_pt_trace() -> bool {
+    false
 }
 
 fn default_input_buffer_size() -> usize {

--- a/fuzz_runner/src/nyx/params.rs
+++ b/fuzz_runner/src/nyx/params.rs
@@ -12,6 +12,7 @@ pub struct QemuParams {
 
     pub dump_python_code_for_inputs: bool,
     pub write_protected_input_buffer: bool,
+    pub dump_pt_trace: bool,
     pub cow_primary_size: Option<u64>,
     pub hprintf_fd: Option<i32>,
 
@@ -100,6 +101,7 @@ impl QemuParams {
         nyx_ops += &format!(",workdir={}", workdir);
         nyx_ops += &format!(",sharedir={}", sharedir);
         nyx_ops += &format!(",aux_buffer_size={}", fuzzer_config.runtime.aux_buffer_size());
+        nyx_ops += &format!(",dump_pt_trace={}", fuzzer_config.fuzz.dump_pt_trace);
 
         let mut i = 0;
         for filter in fuzzer_config.fuzz.ipt_filters{
@@ -196,7 +198,8 @@ impl QemuParams {
             cow_primary_size: fuzzer_config.fuzz.cow_primary_size,
             hprintf_fd: fuzzer_config.runtime.hprintf_fd(),
             aux_buffer_size: fuzzer_config.runtime.aux_buffer_size(),
-            time_limit: fuzzer_config.fuzz.time_limit
+            time_limit: fuzzer_config.fuzz.time_limit,
+            dump_pt_trace: fuzzer_config.fuzz.dump_pt_trace,
         }
     }
 


### PR DESCRIPTION
Adds `dump_pt_trace` as config parameter to enable trace dump via `config.ron`.

QEMU-Nyx Property: https://github.com/nyx-fuzz/QEMU-Nyx/blob/ff1c89732115274e912a2809fcba58e67df23dfd/nyx/interface.c#L467