### PR TITLE
Update cbindgen dependency

### DIFF
--- a/libnyx/Cargo.toml
+++ b/libnyx/Cargo.toml
@@ -8,7 +8,7 @@ name = "libnyx"
 crate-type = ["lib", "staticlib", "dylib"]
 
 [build-dependencies]
-cbindgen = "0.24.3"
+cbindgen = "0.28.0"
 
 [dependencies]
 config={path="../config"}


### PR DESCRIPTION
I see github raises some security advisory about one of the libafl fuzzer (which depends on libnyx).
and it is due to the outdated cbindgen version